### PR TITLE
fix: ingress should target correct service name

### DIFF
--- a/charts/immich/templates/ingress.yaml
+++ b/charts/immich/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "immich.fullname" $ }}
+                name: {{ include "immich-server.name" $ }}
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}


### PR DESCRIPTION
Thanks for this chart, it's amazing.

I noticed that the ingress is not targeting the correct service name, let me know if this change makes sense